### PR TITLE
change reference syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # `data2objects`
 
-Transform nested data structures into Python objects.
+Transform self-documenting config files and data structures into Python objects.
 
 [![PyPI](https://img.shields.io/pypi/v/data2objects)](https://pypi.org/project/data2objects/)
 [![Tests](https://github.com/jla-gardner/data2objects/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/jla-gardner/data2objects/actions/workflows/ci.yml)
@@ -14,15 +14,11 @@ Transform nested data structures into Python objects.
 
 ## Installation
 
-```
-pip install data2objects
-```
+`pip install data2objects` or just copy `data2objects.py` into your project.
 
-or just copy `data2objects.py` into your project.
+## Examples
 
-## Usage
-
-`data2objects` is intended to be used alongside config files, e.g. `.yaml`s:
+The best way to explain the use of `data2objects` is via an example. Consider the following `config.yaml` file:
 
 ```yaml
 backbone:
@@ -30,69 +26,63 @@ backbone:
     hidden_size: 1024
 readout:
     +torch.nn.Linear:
-        in_features: '!~/backbone/hidden_size'
+        in_features: =/backbone/hidden_size
         out_features: 1
 ```
 
-Hand off the `dict`-like structure returned by `yaml.safe_load` to `data2objects.from_dict` to:
-- resolve references prefixed by `"!"` (using both global `"!~/a/b/c"` and relative `"!../../d/e"` paths)
-- import any objects/classes/functions prefixed by `"+"`
-- call any functions/classes as appropriate:
-    - using no arguments for any `str` prefixed by `"+"` ending with `"()"`
-    - using keyword arguments for any `str` prefixed by `"+"` found as a key in a mapping with exactly one key-value pair
-    - using a single positional argument for any `str` prefixed by `"+"` found as a key in a mapping with exactly one key-value pair
-
-(see documentation below for more details)
+Parsing this file using `data2objects.from_yaml` returns the following:
 
 ```python
-import yaml  # pip install pyyaml if necessary
-from data2objects import from_dict
-
-with open("config.yaml") as f:
-    data = yaml.safe_load(f)
-
-config = from_dict(data)
-print(config)
-```
-
-```
+>>> import data2objects
+>>> config = data2objects.from_yaml("config.yaml")
+>>> print(config)
 {'backbone': {'activation': SiLU(), 'hidden_size': 1024}, 
  'readout': Linear(in_features=1024, out_features=1, bias=True)}
 ```
 
-Combine with the fantastic [dacite](https://github.com/konradhalas/dacite) library to instantiate nested dataclasses as config objects:
+Under-the-hood, `data2objects` has done the following:
 
-```python
-from dataclasses import dataclass
-import dacite
-import torch
-
-@dataclass
-class Backbone:
-    activation: torch.nn.Module
-    hidden_size: int
-
-@dataclass
-class Config:
-    backbone: Backbone
-    readout: torch.nn.Module
-
-
-final_config = dacite.from_dict(Config, config)
-print(final_config)
-```
-
-```
-Config(
-    backbone=Backbone(activation=SiLU(), hidden_size=1024), 
-    readout=Linear(in_features=1024, out_features=1, bias=True)
-)
-```
+- identified any "reference strings" prefixed by `"="` and replaced them with the corresponding values in the nested data structure
+   - hence `=/backbone/hidden_size` was replaced with `1024`.
+- identified any "object instantiation strings" prefixed by `"+"`, imported the corresponding objects from the provided modules and:
+   - called the object if the instantiation string ends with `"()"`, i.e. `"+torch.nn.SiLU()"` created a `SiLU` object.
+   - called the object with keyword arguments if the instantiation string ends with a mapping, i.e. `"+torch.nn.Linear: {in_features: =/backbone/hidden_size, out_features: 1}"` created a `Linear` object with `in_features=1024` and `out_features=1`.
 
 
 ## Documentation
 
-`data2objects` exposes a single function, `from_dict`, which can be used to transform a nested data structure into a set of instantiated Python objects:
+`data2objects` exposes two functions, `from_dict` and `from_yaml`, which can be used to transform a nested data structure into a set of instantiated Python objects.
+
+
+### `from_yaml`
+
+```python
+def from_yaml(thing: str | Path, modules: list[object] | None = None) -> dict:
+```
+
+> Load a nested dictionary from a yaml file or string, 
+> and parse it using `data2objects.from_dict`.
+>
+> If `thing` points to an existing file, the data in the file is loaded.
+> Otherwise, the string is treated as containing the raw yaml data.
+> 
+> ### Parameters
+> 
+> thing: `str | Path`
+>     The yaml file or string to load.
+> 
+> modules: `list[object] | None`
+>     A list of modules to look up non-fully qualified names in.
+
+> ### Returns
+> 
+> `dict`
+>     The transformed data.
+
+
+---
+
+### `from_dict`
 
 ```python
 def from_dict(
@@ -100,55 +90,52 @@ def from_dict(
 ) -> dict[K, V | Any]:
 ```
 
-
 > Transform a nested `data` structure into instantiated Python objects.
-> 
 > This function recursively processes the input data, and applies the
 > following special handling to any `str` objects:
 > 
 > **Reference handling**:
 > 
-> Any leaf-nodes within `data` that are strings and start with `"!"` are
-> interpreted as references to other parts of `data`. The following syntax is
-> supported:
-> 
-> * `"~path"`: resolve `path` relative to the root of the `data` structure.
-> * `"path"`: resolve `path` relative to the current location.
-> * `"../path"`: resolve `path` relative to the parent of the current location.
-> * and so on like normal unix paths
+> Any leaf-nodes within `data` that are strings and start with `"="` are
+> interpreted as references to other parts of `data`. The syntax for these
+> references follows the same rules as unix paths:
+> * `"=/path"`: resolve `path` relative to the root of the `data` structure.
+> * `"=./path"`: resolve `path` relative to the current working directory.
+> * `"=../path"`: resolve `path` relative to the parent of the current working
+>   directory.
 > 
 > **Object instantiation**:
 > 
 > The following handling applied to any `str` objects found within `data` (
 > either as a key or value) that start with `"+"`:
-> 
 > 1. attempt to import the python object specified by the string:
->     e.g. the string `"+torch.nn.Tanh"` will be converted to the `Tanh`
->     **class** (not an instance) from the `torch.nn` module. If the string is
->     not an absolute path (i.e. does not contain any dots), we attempt to
->     import it from the python standard library, or any of the provided
->     modules:
->     - `"+Path"` with `modules=[pathlib]` will be converted to the `Path`
->         **class** from the `pathlib` module.
->     - `"+tuple"` will be converted to the `tuple` **type**.
+>    e.g. the string `"+torch.nn.Tanh"` will be converted to the `Tanh`
+>    **class** (not an instance) from the `torch.nn` module. If the string is
+>    not an absolute path (i.e. does not contain any dots), we attempt to
+>    import it from the python standard library, or any of the provided
+>    modules:
+>    - `"+Path"` with `modules=[pathlib]` will be converted to the `Path`
+>      **class** from the `pathlib` module.
+>    - `"+tuple"` will be converted to the `tuple` **type**.
 > 2. if the string ends with a `"()"`, the resulting object is called with
->     no arguments e.g. `"+my_module.MyClass()"` will be converted to an
->     **instance** of `MyClass` from `my_module`.
+>    no arguments e.g. `"+my_module.MyClass()"` will be converted to an
+>    **instance** of `MyClass` from `my_module`. This is equivalent to
+>    `+my_module.MyClass: {}` (see below).
 > 3. if the string is found as key in a mapping with exactly one key-value
->     pair, then:
->     - if the value is itself a mapping, the single-item mapping is replaced
->         with the result of calling the imported object with the recursively
->         instantiated values as **keyword arguments**
->     - otherwise, the single-item mapping is replaced with the result of
->         calling the imported object with the instantiated value as a single
->         **positional argument**
+>    pair, then:
+>    - if the value is itself a mapping, the single-item mapping is replaced
+>      with the result of calling the imported object with the recursively
+>      instantiated values as **keyword arguments**
+>    - otherwise, the single-item mapping is replaced with the result of
+>      calling the imported object with the instantiated value as a single
+>      **positional argument**
 > 
 > ### Parameters
 > 
-> `data`
+> data: `dict[K, V]`
 >     The data to transform.
 > 
-> `modules`
+> modules: `list[object] | None`
 >     A list of modules to look up non-fully qualified names in.
 > 
 > ### Returns
@@ -160,59 +147,77 @@ def from_dict(
 > 
 > A basic example:
 > 
->     >>> from_dict({"activation": "+torch.nn.Tanh()"})
->     {'activation': Tanh()}
+> ```python
+> >>> instantiate_from_data({"activation": "+torch.nn.Tanh()"})
+> {'activation': Tanh()}
+> ```
 > 
 > Note the importance of trailing parentheses:
 > 
->     >>> from_dict({"activation": "+torch.nn.Tanh"})
->     {'activation': <class 'torch.nn.modules.activation.Tanh'>}
+> ```python
+> >>> instantiate_from_data({"activation": "+torch.nn.Tanh"})
+> {'activation': <class 'torch.nn.modules.activation.Tanh'>}
+> ```
 > 
-> Alternatively, point `from_dict` to automatically import
+> Alternatively, point `instantiate_from_data` to automatically import
 > from `torch.nn`:
 > 
->     >>> from_dict({"activation": "+Tanh()"}, modules=[torch.nn])
->     {'activation': Tanh()}
+> ```python
+> >>> instantiate_from_data({"activation": "+Tanh()"}, modules=[torch.nn])
+> {'activation': Tanh()}
+> ```
 > 
 > Use single-item mappings to instantiate classes/call functions with
 > arguments. The following syntax will internally import `MyClass` from
 > `my_module`, and call it as `MyClass(x=1, y=2)` with explicit keyword
 > arguments:
 > 
->     >>> from_dict({
->     ...     "activation": "+torch.nn.ReLU()",
->     ...     "model": {
->     ...         "+MyClass": {"x": 1, "y": 2}
->     ...     }
->     ... })
->     {'activation': ReLU(), 'model': MyClass(x=1, y=2)}
+> ```python
+> >>> instantiate_from_data({
+> ...     "activation": "+torch.nn.ReLU()",
+> ...     "model": {
+> ...         "+MyClass": {"x": 1, "y": 2}
+> ...     }
+> ... })
+> {'activation': ReLU(), 'model': MyClass(x=1, y=2)}
+> ```
 > 
 > In contrast, the following syntax call the imported objects with a single
 > positional argument:
 > 
->     >>> from_dict({"+len": [1, 2, 3]})
->     3  # i.e. len([1, 2, 3])
+> ```python
+> >>> instantiate_from_data({"+len": [1, 2, 3]})
+> 3  # i.e. len([1, 2, 3])
+> ```
 > 
-> Mappings with multiple keys are still processed, but are never used to
+> Mapping with multiple keys are still processed, but are never used to
 > instantiate classes/call functions:
 > 
->     >>> from_dict({"+len": [1, 2, 3], "+print": "hello"})
->     {<built-in function len>: [1, 2, 3], <built-in function print>: 'hello'}
+> ```python
+> >>> instantiate_from_data({"+len": [1, 2, 3], "+print": "hello"})
+> {<built-in function len>: [1, 2, 3], <built-in function print>: 'hello'}
+> ```
 > 
-> `from_dict` also works with arbitrary nesting:
+> `instantiate_from_data` also works with arbitrary nesting:
 > 
->     >>> from_dict({"model": {"activation": "+torch.nn.Tanh()"}})
->     {'model': {'activation': Tanh()}}
+> ```python
+> >>> instantiate_from_data({"model": {"activation": "+torch.nn.Tanh()"}})
+> {'model': {'activation': Tanh()}}
+> ```
 > 
-> **Caution**: `from_dict` can lead to side-effects!
+> **Caution**: `instantiate_from_data` can lead to side-effects!    
 > 
->     >>> from_dict({"+print": "hello"})
->     hello
+> ```python
+> >>> instantiate_from_data({"+print": "hello"})
+> hello
+> ```
 > 
 > References are resolved before object instantiation, so all of the following
 > will resolve the `"length"` field to `3`:
 > 
->     >>> from_dict({"args": [1, 2, 3], "length": {"+len": "!../args"}})
->     3
->     >>> from_dict({"args": [1, 2, 3], "length": {"+len": "!~args"}})
->     3
+> ```python
+> >>> instantiate_from_data({"args": [1, 2, 3], "length": {"+len": "!../args"}})
+> 3
+> >>> instantiate_from_data({"args": [1, 2, 3], "length": {"+len": "!~args"}})
+> 3
+> ```

--- a/data2objects.py
+++ b/data2objects.py
@@ -176,7 +176,11 @@ def _fill_referenced_parts_recursive(
 ) -> collections.abc.Mapping:
     new_data = {}
     for key, value in data.items():
-        if isinstance(value, str) and value.startswith(REFERENCE_PREFIX):
+        if (
+            isinstance(value, str)
+            and value.startswith(REFERENCE_PREFIX)
+            and value != REFERENCE_PREFIX
+        ):
             new_data[key] = copy.deepcopy(
                 index_into(global_data, value, current_path)
             )
@@ -422,5 +426,10 @@ def from_yaml(thing: str | Path, modules: list[object] | None = None) -> dict:
 
     else:
         data = yaml.safe_load(thing)
+        if not isinstance(data, dict):
+            raise ValueError(
+                f"We could not load {thing} as a yaml file, and it does not "
+                "appear to be valid yaml."
+            )
 
     return from_dict(data, modules)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 keywords = []
-dependencies = []
+dependencies = ["pyyaml"]
 requires-python = ">=3.8"
 
 [project.optional-dependencies]

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -83,19 +83,19 @@ def test_index_into():
         index_into(data, "", [])
 
     with pytest.raises(ValueError, match="is empty"):
-        from_dict({"a": "!~"})
+        from_dict({"a": "="})
 
 
 def test_referencing():
     data = {
-        "a": {"b": "!~c"},  # refer to c absolutely
+        "a": {"b": "=/c"},  # refer to c absolutely
         "c": 2,
     }
     obj = from_dict(data)
     assert obj["a"]["b"] == 2
 
     data = {
-        "a": {"b": "!../c"},  # refer to c relative to a
+        "a": {"b": "=../c"},  # refer to c relative to a
         "c": 2,
     }
     obj = from_dict(data)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,9 +1,10 @@
+from pathlib import Path
 from typing import cast
 
 import helpers
 import pytest
 
-from data2objects import from_dict, index_into, process_data_str
+from data2objects import from_dict, index_into, process_data_str, from_yaml
 
 
 def test_basics():
@@ -29,6 +30,26 @@ def test_errors():
     data = {"+helpers.CONSTANT": {"x": 1, "y": 2}}
     with pytest.raises(ValueError, match="is not callable"):
         from_dict(data)
+
+
+def test_from_yaml(tmp_path: Path):
+    data = "a: 1"
+    assert from_yaml(data) == {"a": 1}
+
+    file = tmp_path / "data.yaml"
+    file.write_text("a: 1")
+    assert from_yaml(file) == {"a": 1}
+
+    with pytest.raises(ValueError, match="could not load"):
+        from_yaml("does_not_exist.yaml")
+
+
+def test_isolated_prefixes():
+    data = {"a": "+"}
+    assert from_dict(data) == {"a": "+"}
+
+    data = {"a": "="}
+    assert from_dict(data) == {"a": "="}
 
 
 def test_single_positional_arg(capsys):
@@ -81,9 +102,6 @@ def test_index_into():
 
     with pytest.raises(ValueError, match="is empty"):
         index_into(data, "", [])
-
-    with pytest.raises(ValueError, match="is empty"):
-        from_dict({"a": "="})
 
 
 def test_referencing():

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -4,7 +4,7 @@ from typing import cast
 import helpers
 import pytest
 
-from data2objects import from_dict, index_into, process_data_str, from_yaml
+from data2objects import from_dict, from_yaml, index_into, process_data_str
 
 
 def test_basics():


### PR DESCRIPTION
change the syntax for referencing from

```yaml
a:
  b: "!~/c"
c: 2
```

to

```yaml
a:
  b: =/c
c: 2
```
